### PR TITLE
AP_NavEKF3: external AHRS modifications on arducopter 4.4.4

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1110,14 +1110,6 @@ AP_InertialSensor::detect_backends(void)
 // macro for use by HAL_INS_PROBE_LIST
 #define GET_I2C_DEVICE(bus, address) hal.i2c_mgr->get_device(bus, address)
 
-#if HAL_EXTERNAL_AHRS_ENABLED
-    // if enabled, make the first IMU the external AHRS
-    const int8_t serial_port = AP::externalAHRS().get_port(AP_ExternalAHRS::AvailableSensor::IMU);
-    if (serial_port >= 0) {
-        ADD_BACKEND(new AP_InertialSensor_ExternalAHRS(*this, serial_port));
-    }
-#endif
-
 #if AP_SIM_INS_ENABLED
     for (uint8_t i=0; i<AP::sitl()->imu_count; i++) {
         ADD_BACKEND(AP_InertialSensor_SITL::detect(*this, i==1?INS_SITL_SENSOR_B:INS_SITL_SENSOR_A));
@@ -1255,6 +1247,14 @@ AP_InertialSensor::detect_backends(void)
     // no INS device
 #else
     #error Unrecognised HAL_INS_TYPE setting
+#endif
+
+#if HAL_EXTERNAL_AHRS_ENABLED
+    // if enabled, make the last IMU the external AHRS
+    const int8_t serial_port = AP::externalAHRS().get_port(AP_ExternalAHRS::AvailableSensor::IMU);
+    if (serial_port >= 0) {
+        ADD_BACKEND(new AP_InertialSensor_ExternalAHRS(*this, serial_port));
+    }
 #endif
 
     if (_backend_count == 0) {

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -344,7 +344,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Increment: 0.0001
     // @User: Advanced
     // @Units: rad/s
-    AP_GROUPINFO("GYRO_P_NSE", 24, NavEKF3, _gyrNoise, GYRO_P_NSE_DEFAULT),
+    AP_GROUPINFO("GYRO_P_NSE", 24, NavEKF3, _gyrNoise[0], GYRO_P_NSE_DEFAULT),
 
     // @Param: ACC_P_NSE
     // @DisplayName: Accelerometer noise (m/s^2)
@@ -361,7 +361,7 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
     // @Range: 0.00001 0.001
     // @User: Advanced
     // @Units: rad/s/s
-    AP_GROUPINFO("GBIAS_P_NSE", 26, NavEKF3, _gyroBiasProcessNoise, GBIAS_P_NSE_DEFAULT),
+    AP_GROUPINFO("GBIAS_P_NSE", 26, NavEKF3, _gyroBiasProcessNoise[0], GBIAS_P_NSE_DEFAULT),
 
     // 27 previously used for EK2_GSCL_P_NSE parameter that has been removed
 
@@ -733,6 +733,78 @@ const AP_Param::GroupInfo NavEKF3::var_info2[] = {
     // @User: Advanced
     // @Units: m
     AP_GROUPINFO("GPS_VACC_MAX", 10, NavEKF3, _gpsVAccThreshold, 0.0f),
+
+    // @Param: GBIAS_P_NSE2
+    // @DisplayName: Rate gyro bias stability (rad/s/s)
+    // @Description: This state  process noise controls growth of the gyro delta angle bias state error estimate. Increasing it makes rate gyro bias estimation faster and noisier.
+    // @Range: 0.00001 0.001
+    // @User: Advanced
+    // @Units: rad/s/s
+    AP_GROUPINFO("GBIAS_P_NSE2", 11, NavEKF3, _gyroBiasProcessNoise[1], GBIAS_P_NSE_DEFAULT),
+
+    // @Param: GYRO_P_NSE2
+    // @DisplayName: Rate gyro noise (rad/s)
+    // @Description: This control disturbance noise controls the growth of estimated error due to gyro measurement errors excluding bias. Increasing it makes the flter trust the gyro measurements less and other measurements more.
+    // @Range: 0.0001 0.1
+    // @Increment: 0.0001
+    // @User: Advanced
+    // @Units: rad/s
+    AP_GROUPINFO("GYRO_P_NSE2", 12, NavEKF3, _gyrNoise[1], GYRO_P_NSE_DEFAULT),
+
+    // @Param: GBIAS_P_NSE3
+    // @DisplayName: Rate gyro bias stability (rad/s/s)
+    // @Description: This state  process noise controls growth of the gyro delta angle bias state error estimate. Increasing it makes rate gyro bias estimation faster and noisier.
+    // @Range: 0.00001 0.001
+    // @User: Advanced
+    // @Units: rad/s/s
+    AP_GROUPINFO("GBIAS_P_NSE3", 13, NavEKF3, _gyroBiasProcessNoise[2], GBIAS_P_NSE_DEFAULT),
+
+    // @Param: GYRO_P_NSE3
+    // @DisplayName: Rate gyro noise (rad/s)
+    // @Description: This control disturbance noise controls the growth of estimated error due to gyro measurement errors excluding bias. Increasing it makes the flter trust the gyro measurements less and other measurements more.
+    // @Range: 0.0001 0.1
+    // @Increment: 0.0001
+    // @User: Advanced
+    // @Units: rad/s
+    AP_GROUPINFO("GYRO_P_NSE3", 14, NavEKF3, _gyrNoise[2], GYRO_P_NSE_DEFAULT),
+
+#if INS_MAX_INSTANCES > 3
+    // @Param: GBIAS_P_NSE4
+    // @DisplayName: Rate gyro bias stability (rad/s/s)
+    // @Description: This state  process noise controls growth of the gyro delta angle bias state error estimate. Increasing it makes rate gyro bias estimation faster and noisier.
+    // @Range: 0.00001 0.001
+    // @User: Advanced
+    // @Units: rad/s/s
+    AP_GROUPINFO("GBIAS_P_NSE4", 15, NavEKF3, _gyroBiasProcessNoise[3], GBIAS_P_NSE_DEFAULT),
+
+    // @Param: GYRO_P_NSE4
+    // @DisplayName: Rate gyro noise (rad/s)
+    // @Description: This control disturbance noise controls the growth of estimated error due to gyro measurement errors excluding bias. Increasing it makes the flter trust the gyro measurements less and other measurements more.
+    // @Range: 0.0001 0.1
+    // @Increment: 0.0001
+    // @User: Advanced
+    // @Units: rad/s
+    AP_GROUPINFO("GYRO_P_NSE4", 16, NavEKF3, _gyrNoise[3], GYRO_P_NSE_DEFAULT),
+#endif // INS_MAX_INSTANCES > 3
+
+#if INS_MAX_INSTANCES > 4
+    // @Param: GBIAS_P_NSE5
+    // @DisplayName: Rate gyro bias stability (rad/s/s)
+    // @Description: This state  process noise controls growth of the gyro delta angle bias state error estimate. Increasing it makes rate gyro bias estimation faster and noisier.
+    // @Range: 0.00001 0.001
+    // @User: Advanced
+    // @Units: rad/s/s
+    AP_GROUPINFO("GBIAS_P_NSE5", 17, NavEKF3, _gyroBiasProcessNoise[4], GBIAS_P_NSE_DEFAULT),
+
+    // @Param: GYRO_P_NSE5
+    // @DisplayName: Rate gyro noise (rad/s)
+    // @Description: This control disturbance noise controls the growth of estimated error due to gyro measurement errors excluding bias. Increasing it makes the flter trust the gyro measurements less and other measurements more.
+    // @Range: 0.0001 0.1
+    // @Increment: 0.0001
+    // @User: Advanced
+    // @Units: rad/s
+    AP_GROUPINFO("GYRO_P_NSE5", 18, NavEKF3, _gyrNoise[4], GYRO_P_NSE_DEFAULT),
+#endif // INS_MAX_INSTANCES > 4
 
     AP_GROUPEND
 };

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -24,6 +24,7 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_NavEKF/AP_Nav_Common.h>
 #include <AP_NavEKF/AP_NavEKF_Source.h>
+#include <AP_InertialSensor/AP_InertialSensor_config.h>
 
 class NavEKF3_core;
 class EKFGSF_yaw;
@@ -388,9 +389,9 @@ private:
     AP_Float _wndVarHgtRateScale;   // scale factor applied to wind process noise due to height rate
     AP_Float _magEarthProcessNoise; // Earth magnetic field process noise : gauss/sec
     AP_Float _magBodyProcessNoise;  // Body magnetic field process noise : gauss/sec
-    AP_Float _gyrNoise;             // gyro process noise : rad/s
+    AP_Float _gyrNoise[INS_MAX_INSTANCES];             // gyro process noise : rad/s
     AP_Float _accNoise;             // accelerometer process noise : m/s^2
-    AP_Float _gyroBiasProcessNoise; // gyro bias state process noise : rad/s
+    AP_Float _gyroBiasProcessNoise[INS_MAX_INSTANCES]; // gyro bias state process noise : rad/s
     AP_Float _accelBiasProcessNoise;// accel bias state process noise : m/s^2
     AP_Int16 _hgtDelay_ms;          // effective average delay of Height measurements relative to inertial measurements (msec)
     AP_Int16  _gpsVelInnovGate;     // Percentage number of standard deviations applied to GPS velocity innovation consistency check

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -1067,7 +1067,7 @@ void NavEKF3_core::CovariancePrediction(Vector3F *rotVarVecPtr)
     Vector14 processNoiseVariance = {};
 
     if (!inhibitDelAngBiasStates) {
-        ftype dAngBiasVar = sq(sq(dt) * constrain_ftype(frontend->_gyroBiasProcessNoise, 0.0, 1.0));
+        ftype dAngBiasVar = sq(sq(dt) * constrain_ftype(frontend->_gyroBiasProcessNoise[gyro_index_active], 0.0, 1.0));
         for (uint8_t i=0; i<=2; i++) processNoiseVariance[i] = dAngBiasVar;
     }
 
@@ -1170,7 +1170,7 @@ void NavEKF3_core::CovariancePrediction(Vector3F *rotVarVecPtr)
         zeroRows(P,0,3);
         zeroCols(P,0,3);
     } else {
-        ftype _gyrNoise = constrain_ftype(frontend->_gyrNoise, 0.0f, 1.0f);
+        ftype _gyrNoise = constrain_ftype(frontend->_gyrNoise[gyro_index_active], 0.0f, 1.0f);
         daxVar = dayVar = dazVar = sq(dt*_gyrNoise);
     }
     ftype _accNoise = badIMUdata ? BAD_IMU_DATA_ACC_P_NSE : constrain_ftype(frontend->_accNoise, 0.0f, BAD_IMU_DATA_ACC_P_NSE);


### PR DESCRIPTION
Changes to aid in testing the Anello X3:
- Initializes the external AHRS as the final IMU instance.
- Adds individual gyro bias noise and gyro noise parameters for each IMU instance. 